### PR TITLE
Change the get/set coordinates by signed chars

### DIFF
--- a/libraries/Colorduino/Colorduino.h
+++ b/libraries/Colorduino/Colorduino.h
@@ -286,8 +286,8 @@ class ColorduinoObject {
 
   // get a pixel for writing in the offscreen framebuffer, return null if out of screen
   PixelRGB *GetPixel(char x, char y) {
-    if ( x < 0 || x >= COLORDUINO_SCREEN_WIDTH ||
-         y < 0 || y >= COLORDUINO_SCREEN_HEIGHT ) 
+    if ( x < 0 || x >= ColorduinoScreenWidth ||
+         y < 0 || y >= ColorduinoScreenHeight ) 
     {
       return 0;
     }
@@ -296,8 +296,8 @@ class ColorduinoObject {
 
   // get a pixel from the active framebuffer, return null if out of screen
   PixelRGB *GetDrawPixel(char x, char y) {
-    if ( x < 0 || x >= COLORDUINO_SCREEN_WIDTH ||
-         y < 0 || y >= COLORDUINO_SCREEN_HEIGHT ) 
+    if ( x < 0 || x >= ColorduinoScreenWidth ||
+         y < 0 || y >= ColorduinoScreenHeight ) 
     {
       return 0;
     }

--- a/libraries/Colorduino/Colorduino.h
+++ b/libraries/Colorduino/Colorduino.h
@@ -284,24 +284,43 @@ class ColorduinoObject {
     sei();
   }
 
-  // get a pixel for writing in the offscreen framebuffer
-  PixelRGB *GetPixel(unsigned char x,unsigned char y) {
+  // get a pixel for writing in the offscreen framebuffer, return null if out of screen
+  PixelRGB *GetPixel(char x, char y) {
+    if ( x < 0 || x >= COLORDUINO_SCREEN_WIDTH ||
+         y < 0 || y >= COLORDUINO_SCREEN_HEIGHT ) 
+    {
+      return 0;
+    }
     return curWriteFrame + (y * ColorduinoScreenWidth) + x;
   }
 
-  // get a pixel from the active framebuffer
-  PixelRGB *GetDrawPixel(unsigned char x,unsigned char y) {
+  // get a pixel from the active framebuffer, return null if out of screen
+  PixelRGB *GetDrawPixel(char x, char y) {
+    if ( x < 0 || x >= COLORDUINO_SCREEN_WIDTH ||
+         y < 0 || y >= COLORDUINO_SCREEN_HEIGHT ) 
+    {
+      return 0;
+    }
     return curDrawFrame + (y * ColorduinoScreenWidth) + x;
   }
 
   // set a pixel in the offscreen frame buffer
-  void SetPixel(unsigned char x, unsigned char y, unsigned char r, unsigned char g, unsigned char b)
-    {
-      PixelRGB *p = GetPixel(x,y);
+  void SetPixel(char x, char y, unsigned char r, unsigned char g, unsigned char b) {
+    PixelRGB *p = GetPixel(x,y);
+    if (p) {
       p->r = r;
       p->g = g;
       p->b = b;
     }
+  }
+
+  // set a pixel in the offscreen frame buffer
+  void SetPixel(char x, char y, const PixelRGB & color) {
+    PixelRGB * p = GetPixel(x,y);
+    if (p) {
+      *p = color;
+    }
+  }
 
 /********************************************************
 Name: ColorFill


### PR DESCRIPTION
the idea is to be able to "get/set" out of screen in order to not do the calculation "is outside of screen" outside of this class.

Why would I want that ?

I made a text display class which may print out of screen for long texts. I think it is the responsability of the Colorduino object to not write out of it's frame buffer. Objects using Colorduino class should not have to take care of that. That way I can do that without beeing afraid of accessing out of frame buffer :
```c
Colorduino.SetPixel(x + row, y + col, color);	
```